### PR TITLE
Add Javadocs to svg-service classes

### DIFF
--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/VulcanFtSvgServiceApplication.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/VulcanFtSvgServiceApplication.java
@@ -3,11 +3,20 @@ package com.btsaunde.vulcanft.svgservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Entry point for the SVG generation service. This class simply boots the
+ * Spring application.
+ */
 @SpringBootApplication
 public class VulcanFtSvgServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(VulcanFtSvgServiceApplication.class, args);
-	}
+        /**
+         * Launches the Spring Boot application.
+         *
+         * @param args application arguments passed on the command line
+         */
+        public static void main(String[] args) {
+                SpringApplication.run(VulcanFtSvgServiceApplication.class, args);
+        }
 
 }

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/controller/FilamentLabelController.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/controller/FilamentLabelController.java
@@ -17,15 +17,27 @@ import org.springframework.web.bind.annotation.RestController;
 import com.btsaunde.vulcanft.svgservice.model.FilamenLabel;
 import com.btsaunde.vulcanft.svgservice.service.FilamentLabelService;
 
+/**
+ * REST controller that exposes endpoints for generating filament label images.
+ */
 @RestController
 @RequestMapping("/api/label")
 public class FilamentLabelController {
 
+    /** Service responsible for generating label images from templates. */
     @Autowired
     private FilamentLabelService filamentLabelService;
 
+    /** Logger instance for this controller. */
     private static final Logger logger = LoggerFactory.getLogger(FilamentLabelController.class);
 
+    /**
+     * Generates a filament label image using the JSON body of the request to
+     * populate the template.
+     *
+     * @param filament object containing all of the label fields
+     * @return PNG image bytes of the rendered label
+     */
     @PostMapping("/filament")
     public ResponseEntity<byte[]> getFilamentLabelFromJson(@RequestBody FilamenLabel filament) {
         try{
@@ -43,6 +55,10 @@ public class FilamentLabelController {
         }
     }
 
+    /**
+     * Generates a filament label image from request parameters. Each parameter
+     * corresponds to a placeholder in the label template.
+     */
     @GetMapping("/filament")
     public ResponseEntity<byte[]> getFilamentLabel(@RequestParam(value = "brand", defaultValue = "Bambu Lab") String brand,
                                                     @RequestParam(value = "type", defaultValue = "PLA") String type,

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/controller/HomeController.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/controller/HomeController.java
@@ -6,9 +6,18 @@ import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Simple controller used as a health check endpoint for the service.
+ */
 @RestController
 public class HomeController {
 
+    /**
+     * Basic home endpoint which returns a JSON structure indicating that the
+     * service is running.
+     *
+     * @return map containing a single <code>status</code> field
+     */
     @GetMapping("/")
     public Map<String, String> home() {
         Map<String, String> response = new HashMap<>();

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/controller/SvgToPngController.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/controller/SvgToPngController.java
@@ -10,13 +10,24 @@ import org.springframework.web.bind.annotation.*;
 
 import com.btsaunde.vulcanft.svgservice.service.SvgToPngConversionService;
 
+/**
+ * Controller that exposes an endpoint to convert raw SVG markup into PNG
+ * images.
+ */
 @RestController
 @RequestMapping("/api/svg")
 public class SvgToPngController {
 
+    /** Service that handles the SVG to PNG conversion logic. */
     @Autowired
     private SvgToPngConversionService conversionService;
 
+    /**
+     * Converts a block of SVG markup into a PNG image.
+     *
+     * @param svgCode SVG XML to convert
+     * @return PNG image bytes
+     */
     @PostMapping("/convert")
     public ResponseEntity<byte[]> convertSvgToPng(@RequestBody String svgCode) {
         try {

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/model/FilamenLabel.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/model/FilamenLabel.java
@@ -1,25 +1,47 @@
 package com.btsaunde.vulcanft.svgservice.model;
 
+/**
+ * Data model representing the fields required to populate a filament label.
+ * The properties correspond directly to placeholders used in the SVG template.
+ */
 public class FilamenLabel {
 
+    /** Manufacturer of the filament. */
     private String brand;
+    /** Material type such as PLA or PETG. */
     private String type;
+    /** Product line name. */
     private String line;
+    /** Stock keeping unit. */
     private String sku;
+    /** Display color name. */
     private String colorName;
+    /** Color specified as hex or semicolon separated gradient. */
     private String colorHex;
+    /** Recommended nozzle temperature range. */
     private String nozzleTemp;
+    /** Recommended bed temperature range. */
     private String bedTemp;
+    /** Maximum printer speed in mm/s. */
     private int maxPrintSpeed;
+    /** Drying temperature for the filament. */
     private int dryingTemp;
+    /** Drying time in hours. */
     private int dryingTime;
+    /** Maximum recommended relative humidity. */
     private int maxRh;
+    /** Whether drying is required before use. */
     private boolean dryingRequired;
+    /** Whether the spool is compatible with the AMS system. */
     private boolean amsCompatible;
+    /** Flag indicating if the material releases toxic fumes. */
     private boolean toxicFumes;
+    /** Unique identifier for the spool. */
     private String spoolId;
 
+    // ---------------------------------------------------------------------
     // Getters and Setters
+    // ---------------------------------------------------------------------
     public String getBrand() {
         return brand;
     }

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/FilamentLabelService.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/FilamentLabelService.java
@@ -12,17 +12,28 @@ import org.springframework.stereotype.Service;
 
 import com.btsaunde.vulcanft.svgservice.model.FilamenLabel;
 
+/**
+ * Service responsible for populating the filament label template and converting
+ * the resulting SVG into a PNG image.
+ */
 @Service
 public class FilamentLabelService {
 
+        /** Handles Thymeleaf template rendering. */
         @Autowired
         private TemplateService templateService;
 
+        /** Performs the SVG to PNG conversion. */
         @Autowired
         private SvgToPngConversionService conversionService;
 
+        /** Logger instance for this service. */
         private static final Logger logger = LoggerFactory.getLogger(FilamentLabelService.class);
 
+        /**
+         * Convenience overload that accepts a {@link FilamenLabel} instance and
+         * delegates to the detailed method.
+         */
         public byte[] generateLabelFromTemplate(FilamenLabel filamenLabel) throws IOException, TranscoderException {
 
             return generateLabelFromTemplate(
@@ -44,7 +55,11 @@ public class FilamentLabelService {
                 filamenLabel.isToxicFumes());
         }
     
-        public byte[] generateLabelFromTemplate(String brand, String type, String line, String sku, String colorName, String colorHex, 
+        /**
+         * Generates a label using the provided attributes, renders the SVG
+         * template and converts it to PNG.
+         */
+        public byte[] generateLabelFromTemplate(String brand, String type, String line, String sku, String colorName, String colorHex,
             String nozzleTemp, String bedTemp, int maxPrintSpeed, int dryingTime, int maxRh, String spoolId, int dryingTemp,
             Boolean dryingRequired, Boolean amsCompatible, Boolean toxicFumes) throws IOException, TranscoderException {
         

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/ImageService.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/ImageService.java
@@ -9,9 +9,16 @@ import javax.imageio.ImageIO;
 import java.awt.Image;
 import org.springframework.stereotype.Service;
 
+/**
+ * Utility service that provides basic image manipulation operations used when
+ * generating label graphics.
+ */
 @Service
 public class ImageService {
 
+        /**
+         * Crop the provided image byte array to the specified rectangle.
+         */
         public static byte[] cropImage(byte[] imageBytes, int x, int y, int width, int height) throws IOException {
         // Convert byte array to BufferedImage
         ByteArrayInputStream bis = new ByteArrayInputStream(imageBytes);
@@ -34,6 +41,9 @@ public class ImageService {
         return bos.toByteArray();
     }
 
+        /**
+         * Resize the provided image byte array to the target dimensions.
+         */
         public static byte[] resizeImage(byte[] imageBytes, int targetWidth, int targetHeight) throws IOException {
         // Convert byte array to BufferedImage
         ByteArrayInputStream bis = new ByteArrayInputStream(imageBytes);

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/SvgToPngConversionService.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/SvgToPngConversionService.java
@@ -17,11 +17,19 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Service that handles conversion of SVG markup to PNG images using Apache
+ * Batik.
+ */
 @Service
 public class SvgToPngConversionService {
 
+    /** Logger instance for this service. */
     private static final Logger logger = LoggerFactory.getLogger(SvgToPngConversionService.class);
 
+    /**
+     * Convert an SVG string to a PNG image using the specified DPI for rendering.
+     */
     public byte[] convertSvgToPng(String svgContent, int dpi) throws IOException, TranscoderException {
 
         // Remove any BOM characters
@@ -62,7 +70,10 @@ public class SvgToPngConversionService {
         return outputStream.toByteArray();
     }
 
-    // Method to remove BOM from a string if present
+    /**
+     * Remove any UTF-8 BOM character that may appear at the start of the provided
+     * string.
+     */
     public static String removeBOM(String xmlContent) {
         // Check if BOM is at the beginning of the string
         if (xmlContent.startsWith("\uFEFF")) {

--- a/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/TemplateService.java
+++ b/svg-service/src/main/java/com/btsaunde/vulcanft/svgservice/service/TemplateService.java
@@ -7,9 +7,14 @@ import org.thymeleaf.context.Context;
 
 import java.util.Map;
 
+/**
+ * Service wrapper around Thymeleaf used to populate SVG templates with values
+ * provided by the REST controllers.
+ */
 @Service
 public class TemplateService {
 
+    /** Injected Thymeleaf template engine. */
     @Autowired
     private TemplateEngine templateEngine;  // Inject the TemplateEngine
 

--- a/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/VulcanFtSvgServiceApplicationTests.java
+++ b/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/VulcanFtSvgServiceApplicationTests.java
@@ -3,11 +3,15 @@ package com.btsaunde.vulcanft.svgservice;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+/**
+ * Basic context load test to ensure the Spring application starts correctly.
+ */
 @SpringBootTest
 class VulcanFtSvgServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+        /** Ensure the Spring context can be created. */
+        @Test
+        void contextLoads() {
+        }
 
 }


### PR DESCRIPTION
## Summary
- document entry application class
- add controller comments
- describe the filament label model fields
- document service components and helpers
- annotate basic test class

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68423a573298832b9f6c8594b765bb2d