### PR TITLE
Add svg-service unit tests

### DIFF
--- a/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/FilamentLabelServiceTest.java
+++ b/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/FilamentLabelServiceTest.java
@@ -1,0 +1,62 @@
+package com.btsaunde.vulcanft.svgservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for {@link FilamentLabelService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class FilamentLabelServiceTest {
+
+    @Mock
+    private TemplateService templateService;
+
+    @Mock
+    private SvgToPngConversionService conversionService;
+
+    @InjectMocks
+    private FilamentLabelService service;
+
+    @BeforeEach
+    void setupMocks() throws Exception {
+        when(templateService.processTemplate(eq("filamentLabel"), anyMap())).thenReturn("<svg></svg>");
+        when(conversionService.convertSvgToPng(eq("<svg></svg>"), eq(300))).thenReturn(new byte[] {1,2,3});
+    }
+
+    @Test
+    void generateLabelBuildsVariablesCorrectly() throws Exception {
+        byte[] result = service.generateLabelFromTemplate(
+                "Brand", "PLA", "Line", "1001", "Color", "FF0000;00FF00",
+                "200", "50", 100, 8, 20, "ID1", 60,
+                true, false, false);
+
+        assertArrayEquals(new byte[]{1,2,3}, result);
+
+        ArgumentCaptor<Map<String,Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(templateService).processTemplate(eq("filamentLabel"), captor.capture());
+        Map<String,Object> vars = captor.getValue();
+        assertEquals("Brand", vars.get("brand"));
+        assertEquals("url(#dualGradient)", vars.get("circleFill"));
+        assertEquals("#FF0000", vars.get("colorHex"));
+        assertEquals("#00FF00", vars.get("colorHex2"));
+        assertEquals("Required", vars.get("dryingRequired"));
+        assertEquals("Incompatible", vars.get("amsCompatible"));
+        assertEquals("No", vars.get("toxicFumes"));
+        assertEquals("ID1", vars.get("spoolId"));
+    }
+}

--- a/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/ImageServiceTest.java
+++ b/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/ImageServiceTest.java
@@ -1,0 +1,55 @@
+package com.btsaunde.vulcanft.svgservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ImageService} utilities.
+ */
+class ImageServiceTest {
+
+    private static byte[] createImage(int w, int h) throws Exception {
+        BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+        java.awt.Graphics2D g = img.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, w, h);
+        g.dispose();
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(img, "png", bos);
+        return bos.toByteArray();
+    }
+
+    @Test
+    void cropImageReturnsExpectedSize() throws Exception {
+        byte[] bytes = createImage(10, 10);
+        byte[] cropped = ImageService.cropImage(bytes, 2, 2, 5, 5);
+        BufferedImage img = ImageIO.read(new java.io.ByteArrayInputStream(cropped));
+        assertEquals(5, img.getWidth());
+        assertEquals(5, img.getHeight());
+    }
+
+    @Test
+    void cropImageInvalidParamsThrows() throws Exception {
+        byte[] bytes = createImage(10, 10);
+        assertThrows(IllegalArgumentException.class, () -> ImageService.cropImage(bytes, -1, 0, 5, 5));
+    }
+
+    @Test
+    void resizeImageProducesTargetDimensions() throws Exception {
+        byte[] bytes = createImage(10, 10);
+        byte[] resized = ImageService.resizeImage(bytes, 4, 6);
+        BufferedImage img = ImageIO.read(new java.io.ByteArrayInputStream(resized));
+        assertEquals(4, img.getWidth());
+        assertEquals(6, img.getHeight());
+        assertNotNull(resized);
+    }
+}

--- a/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/SvgToPngConversionServiceTest.java
+++ b/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/SvgToPngConversionServiceTest.java
@@ -1,0 +1,31 @@
+package com.btsaunde.vulcanft.svgservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SvgToPngConversionService}.
+ */
+class SvgToPngConversionServiceTest {
+
+    private final SvgToPngConversionService service = new SvgToPngConversionService();
+
+    @Test
+    void removeBOMStripsLeadingMarker() {
+        String xml = "\uFEFF<svg/>";
+        assertEquals("<svg/>", SvgToPngConversionService.removeBOM(xml));
+    }
+
+    @Test
+    void convertSvgToPngProducesPngBytes() throws Exception {
+        String svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"><rect width=\"10\" height=\"10\" fill=\"red\"/></svg>";
+        byte[] result = service.convertSvgToPng(svg, 300);
+        assertNotNull(result);
+        // PNG magic number
+        byte[] expectedHeader = new byte[] {(byte)0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+        assertArrayEquals(expectedHeader, java.util.Arrays.copyOf(result, 8));
+    }
+}

--- a/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/TemplateServiceTest.java
+++ b/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/service/TemplateServiceTest.java
@@ -1,0 +1,44 @@
+package com.btsaunde.vulcanft.svgservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+/**
+ * Unit tests for {@link TemplateService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TemplateServiceTest {
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @InjectMocks
+    private TemplateService templateService;
+
+    @Test
+    void processTemplateDelegatesToEngine() {
+        when(templateEngine.process(eq("test"), any(Context.class))).thenReturn("result");
+
+        String output = templateService.processTemplate("test", Map.of("k", "v"));
+
+        assertEquals("result", output);
+
+        ArgumentCaptor<Context> captor = ArgumentCaptor.forClass(Context.class);
+        verify(templateEngine).process(eq("test"), captor.capture());
+        assertEquals("v", captor.getValue().getVariable("k"));
+    }
+}


### PR DESCRIPTION
## Summary
- add TemplateService unit test
- add SvgToPngConversionService unit test
- add ImageService unit test
- add FilamentLabelService unit test

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6842425bbdb4832ba1a05627aacb867f