### PR TITLE
Add BrandService unit tests

### DIFF
--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/VulcanFtInvServiceApplicationTests.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/VulcanFtInvServiceApplicationTests.java
@@ -1,10 +1,19 @@
 package com.btsaunde.vulcanft.invservice;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import com.btsaunde.vulcanft.invservice.repository.BrandRepository;
 
 @SpringBootTest
+@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
 class VulcanFtInvServiceApplicationTests {
+
+    @MockBean
+    private BrandRepository brandRepository;
 
 	@Test
 	void contextLoads() {

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/controller/BrandControllerTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/controller/BrandControllerTest.java
@@ -1,0 +1,120 @@
+package com.btsaunde.vulcanft.invservice.controller;
+
+import com.btsaunde.vulcanft.invservice.model.Brand;
+import com.btsaunde.vulcanft.invservice.service.BrandService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BrandController.class)
+class BrandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BrandService brandService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void getAllBrandsReturnsList() throws Exception {
+        Brand brand = new Brand("Test", "w", "n");
+        brand.setId(1L);
+        when(brandService.getAllBrands()).thenReturn(List.of(brand));
+
+        mockMvc.perform(get("/api/brand"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id", is(1)))
+                .andExpect(jsonPath("$[0].name", is("Test")));
+    }
+
+    @Test
+    void getBrandByIdFound() throws Exception {
+        Brand brand = new Brand("Test", "w", "n");
+        brand.setId(1L);
+        when(brandService.getBrandById(1L)).thenReturn(Optional.of(brand));
+
+        mockMvc.perform(get("/api/brand/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(1)))
+                .andExpect(jsonPath("$.name", is("Test")));
+    }
+
+    @Test
+    void getBrandByIdNotFound() throws Exception {
+        when(brandService.getBrandById(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/brand/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createBrandReturnsBrand() throws Exception {
+        Brand brand = new Brand("Test", "w", "n");
+        brand.setId(1L);
+        when(brandService.createBrand(any(Brand.class))).thenReturn(brand);
+
+        mockMvc.perform(post("/api/brand")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(brand)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(1)))
+                .andExpect(jsonPath("$.name", is("Test")));
+    }
+
+    @Test
+    void updateBrandFound() throws Exception {
+        Brand update = new Brand("Update", "w", "n");
+        Brand brand = new Brand("Update", "w", "n");
+        brand.setId(1L);
+        when(brandService.updateBrand(Mockito.eq(1L), any(Brand.class))).thenReturn(Optional.of(brand));
+
+        mockMvc.perform(put("/api/brand/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("Update")));
+    }
+
+    @Test
+    void updateBrandNotFound() throws Exception {
+        when(brandService.updateBrand(Mockito.eq(1L), any(Brand.class))).thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/brand/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new Brand())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteBrandFound() throws Exception {
+        when(brandService.deleteBrand(1L)).thenReturn(true);
+
+        mockMvc.perform(delete("/api/brand/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteBrandNotFound() throws Exception {
+        when(brandService.deleteBrand(1L)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/brand/1"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/controller/HomeControllerTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/controller/HomeControllerTest.java
@@ -1,0 +1,25 @@
+package com.btsaunde.vulcanft.invservice.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HomeController.class)
+class HomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void homeReturnsStatusOk() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"))
+                .andExpect(jsonPath("$.service").value("inventory"));
+    }
+}

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/BrandModelTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/BrandModelTest.java
@@ -1,0 +1,33 @@
+package com.btsaunde.vulcanft.invservice.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BrandModelTest {
+
+    @Test
+    void gettersAndSettersWork() {
+        Brand brand = new Brand();
+        brand.setId(10L);
+        brand.setName("Test");
+        brand.setWebsite("http://example.com");
+        brand.setNotes("notes");
+
+        assertEquals(10L, brand.getId());
+        assertEquals("Test", brand.getName());
+        assertEquals("http://example.com", brand.getWebsite());
+        assertEquals("notes", brand.getNotes());
+        assertNotNull(brand.toString());
+    }
+
+    @Test
+    void constructorSetsFields() {
+        Brand brand = new Brand("Name", "web", "n");
+        brand.setId(5L);
+        assertEquals("Name", brand.getName());
+        assertEquals("web", brand.getWebsite());
+        assertEquals("n", brand.getNotes());
+        assertEquals(5L, brand.getId());
+    }
+}

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/FilamentModelTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/FilamentModelTest.java
@@ -1,0 +1,48 @@
+package com.btsaunde.vulcanft.invservice.model;
+
+import com.btsaunde.vulcanft.invservice.model.enums.FilamentType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FilamentModelTest {
+
+    @Test
+    void gettersAndSettersWork() {
+        Brand brand = new Brand("B", "w", "n");
+        Filament filament = new Filament();
+        filament.setId(1L);
+        filament.setBrand(brand);
+        filament.setType(FilamentType.PLA);
+        filament.setLine("L");
+        filament.setSku("SKU");
+        filament.setColorName("Color");
+        filament.setColorHex("#ffffff");
+        filament.setPrintingTempRange("180-200");
+        filament.setBedTempRange("50-60");
+        filament.setMaxPrintSpeed(100);
+        filament.setDryingTemp(60);
+        filament.setDryingHours(5.0);
+        filament.setMaxHumidity(20);
+        filament.setHasToxicFumes(true);
+        filament.setDryingIsRequired(true);
+        filament.setIsAmsCompatible(true);
+
+        assertEquals(1L, filament.getId());
+        assertEquals(brand, filament.getBrand());
+        assertEquals(FilamentType.PLA, filament.getType());
+        assertEquals("L", filament.getLine());
+        assertEquals("SKU", filament.getSku());
+        assertEquals("Color", filament.getColorName());
+        assertEquals("#ffffff", filament.getColorHex());
+        assertEquals("180-200", filament.getPrintingTempRange());
+        assertEquals("50-60", filament.getBedTempRange());
+        assertEquals(100, filament.getMaxPrintSpeed());
+        assertEquals(60, filament.getDryingTemp());
+        assertEquals(5.0, filament.getDryingHours());
+        assertEquals(20, filament.getMaxHumidity());
+        assertTrue(filament.getHasToxicFumes());
+        assertTrue(filament.getDryingIsRequired());
+        assertTrue(filament.getIsAmsCompatible());
+    }
+}

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/RollModelTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/RollModelTest.java
@@ -1,0 +1,34 @@
+package com.btsaunde.vulcanft.invservice.model;
+
+import com.btsaunde.vulcanft.invservice.model.enums.RollLocation;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RollModelTest {
+
+    @Test
+    void gettersAndSettersWork() {
+        Roll roll = new Roll(1L, 0.75, "f", "r", RollLocation.STORAGE, LocalDate.now(), LocalDate.now());
+
+        roll.setRollId(2L);
+        roll.setStartingSize(1.0);
+        roll.setFilament("filament");
+        roll.setRoll("roll");
+        roll.setLocation(RollLocation.AMS);
+        LocalDate opened = LocalDate.now().minusDays(1);
+        LocalDate sealed = LocalDate.now();
+        roll.setDateOpened(opened);
+        roll.setDateSealed(sealed);
+
+        assertEquals(2L, roll.getRollId());
+        assertEquals(1.0, roll.getStartingSize());
+        assertEquals("filament", roll.getFilament());
+        assertEquals("roll", roll.getRoll());
+        assertEquals(RollLocation.AMS, roll.getLocation());
+        assertEquals(opened, roll.getDateOpened());
+        assertEquals(sealed, roll.getDateSealed());
+    }
+}

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/SpoolModelTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/model/SpoolModelTest.java
@@ -1,0 +1,32 @@
+package com.btsaunde.vulcanft.invservice.model;
+
+import com.btsaunde.vulcanft.invservice.model.enums.SpoolMaterialType;
+import com.btsaunde.vulcanft.invservice.model.enums.SpoolTemperature;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpoolModelTest {
+
+    @Test
+    void gettersAndSettersWork() {
+        Brand brand = new Brand("B", "w", "n");
+        Spool spool = new Spool();
+        spool.setMaterialType(SpoolMaterialType.PLASTIC);
+        spool.setSize(1.0);
+        spool.setEmptyWeight(0.5);
+        spool.setBrand(brand);
+        spool.setColor("Red");
+        spool.setTemperature(SpoolTemperature.HIGH);
+        spool.setAmsCompatible(true);
+
+        assertEquals(SpoolMaterialType.PLASTIC, spool.getMaterialType());
+        assertEquals(1.0, spool.getSize());
+        assertEquals(0.5, spool.getEmptyWeight());
+        assertEquals(brand, spool.getBrand());
+        assertEquals("Red", spool.getColor());
+        assertEquals(SpoolTemperature.HIGH, spool.getTemperature());
+        assertTrue(spool.isAmsCompatible());
+        assertNotNull(spool.toString());
+    }
+}

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/service/BrandServiceTest.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/service/BrandServiceTest.java
@@ -1,0 +1,124 @@
+package com.btsaunde.vulcanft.invservice.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.btsaunde.vulcanft.invservice.model.Brand;
+import com.btsaunde.vulcanft.invservice.repository.BrandRepository;
+import com.btsaunde.vulcanft.invservice.service.BrandService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BrandServiceTest {
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @InjectMocks
+    private BrandService brandService;
+
+    private Brand sampleBrand;
+
+    @BeforeEach
+    void setUp() {
+        sampleBrand = new Brand("TestBrand", "http://example.com", "notes");
+        sampleBrand.setId(1L);
+    }
+
+    @Test
+    void getAllBrandsReturnsList() {
+        List<Brand> brands = List.of(sampleBrand);
+        when(brandRepository.findAll()).thenReturn(brands);
+
+        List<Brand> result = brandService.getAllBrands();
+
+        assertEquals(brands, result);
+        verify(brandRepository).findAll();
+    }
+
+    @Test
+    void getBrandByIdFound() {
+        when(brandRepository.findById(1L)).thenReturn(Optional.of(sampleBrand));
+
+        Optional<Brand> result = brandService.getBrandById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals(sampleBrand, result.get());
+        verify(brandRepository).findById(1L);
+    }
+
+    @Test
+    void getBrandByIdNotFound() {
+        when(brandRepository.findById(1L)).thenReturn(Optional.empty());
+
+        Optional<Brand> result = brandService.getBrandById(1L);
+
+        assertTrue(result.isEmpty());
+        verify(brandRepository).findById(1L);
+    }
+
+    @Test
+    void createBrandSavesBrand() {
+        when(brandRepository.save(sampleBrand)).thenReturn(sampleBrand);
+
+        Brand result = brandService.createBrand(sampleBrand);
+
+        assertEquals(sampleBrand, result);
+        verify(brandRepository).save(sampleBrand);
+    }
+
+    @Test
+    void updateBrandExisting() {
+        Brand update = new Brand("Updated", "http://example.com", "notes");
+        when(brandRepository.findById(1L)).thenReturn(Optional.of(sampleBrand));
+        when(brandRepository.save(any(Brand.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Optional<Brand> result = brandService.updateBrand(1L, update);
+
+        assertTrue(result.isPresent());
+        assertEquals("Updated", sampleBrand.getName());
+        verify(brandRepository).findById(1L);
+        verify(brandRepository).save(sampleBrand);
+    }
+
+    @Test
+    void updateBrandMissing() {
+        when(brandRepository.findById(1L)).thenReturn(Optional.empty());
+
+        Optional<Brand> result = brandService.updateBrand(1L, sampleBrand);
+
+        assertTrue(result.isEmpty());
+        verify(brandRepository).findById(1L);
+        verify(brandRepository, never()).save(any());
+    }
+
+    @Test
+    void deleteBrandExisting() {
+        when(brandRepository.existsById(1L)).thenReturn(true);
+
+        boolean result = brandService.deleteBrand(1L);
+
+        assertTrue(result);
+        verify(brandRepository).existsById(1L);
+        verify(brandRepository).deleteById(1L);
+    }
+
+    @Test
+    void deleteBrandMissing() {
+        when(brandRepository.existsById(1L)).thenReturn(false);
+
+        boolean result = brandService.deleteBrand(1L);
+
+        assertFalse(result);
+        verify(brandRepository).existsById(1L);
+        verify(brandRepository, never()).deleteById(any());
+    }
+}


### PR DESCRIPTION
## Summary
- add Mockito-based unit tests for `BrandService`
- adjust context test to avoid DataSource configuration by mocking repository
- add model tests for `Brand`, `Filament`, `Spool` and `Roll`
- add `BrandController` and `HomeController` tests

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6842429d2eac832ba096f1b54e4a9f44