### PR TITLE
Add API documentation via Spring REST Docs

### DIFF
--- a/inventory-service/pom.xml
+++ b/inventory-service/pom.xml
@@ -26,9 +26,11 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <asciidoctor.version>2.2.2</asciidoctor.version>
+                <spring-restdocs.version>3.0.1</spring-restdocs.version>
+        </properties>
 	<dependencies>
 		<!-- Spring Dependencies -->
 		<dependency>
@@ -39,32 +41,68 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- Spring Data JPA -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<!-- MySQL Driver -->
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-mockmvc</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <!-- Spring Data JPA -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <!-- MySQL Driver -->
+                <dependency>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <!-- H2 Database for testing -->
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<finalName>${project.artifactId}</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoctor-maven-plugin</artifactId>
+                                <version>${asciidoctor.version}</version>
+                                <executions>
+                                        <execution>
+                                                <id>generate-docs</id>
+                                                <phase>prepare-package</phase>
+                                                <goals>
+                                                        <goal>process-asciidoc</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <backend>html</backend>
+                                                        <sourceDirectory>${project.basedir}/src/docs/asciidoc</sourceDirectory>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                                <dependencies>
+                                        <dependency>
+                                                <groupId>org.springframework.restdocs</groupId>
+                                                <artifactId>spring-restdocs-asciidoctor</artifactId>
+                                                <version>${spring-restdocs.version}</version>
+                                        </dependency>
+                                </dependencies>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/inventory-service/src/docs/asciidoc/index.adoc
+++ b/inventory-service/src/docs/asciidoc/index.adoc
@@ -1,0 +1,6 @@
+= Inventory Service API
+:toc: left
+
+== Brand
+
+include::{snippets}/brands-get/http-response.adoc[]

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/VulcanFtInvServiceApplication.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/VulcanFtInvServiceApplication.java
@@ -3,11 +3,19 @@ package com.btsaunde.vulcanft.invservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Entry point for the Inventory Service Spring Boot application.
+ */
 @SpringBootApplication
 public class VulcanFtInvServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(VulcanFtInvServiceApplication.class, args);
-	}
+        /**
+         * Bootstraps the application.
+         *
+         * @param args standard command line arguments
+         */
+        public static void main(String[] args) {
+                SpringApplication.run(VulcanFtInvServiceApplication.class, args);
+        }
 
 }

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/controller/BrandController.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/controller/BrandController.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST controller for CRUD operations on {@link com.btsaunde.vulcanft.invservice.model.Brand Brand} entities.
+ */
 @RestController
 @RequestMapping("/api/brand")
 public class BrandController {
@@ -15,11 +18,22 @@ public class BrandController {
     @Autowired
     private BrandService brandService;
 
+    /**
+     * Retrieve all known brands.
+     *
+     * @return list of brands
+     */
     @GetMapping
     public List<Brand> getAllBrands() {
         return brandService.getAllBrands();
     }
 
+    /**
+     * Retrieve a single brand by its identifier.
+     *
+     * @param id identifier of the brand
+     * @return the brand or 404 if not found
+     */
     @GetMapping("/{id}")
     public ResponseEntity<Brand> getBrandById(@PathVariable Long id) {
         return brandService.getBrandById(id)
@@ -27,11 +41,24 @@ public class BrandController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Create a new brand.
+     *
+     * @param brand brand data
+     * @return persisted brand
+     */
     @PostMapping
     public Brand createBrand(@RequestBody Brand brand) {
         return brandService.createBrand(brand);
     }
 
+    /**
+     * Update an existing brand.
+     *
+     * @param id    identifier of the brand to update
+     * @param brand new values for the brand
+     * @return updated brand or 404 if the brand does not exist
+     */
     @PutMapping("/{id}")
     public ResponseEntity<Brand> updateBrand(@PathVariable Long id, @RequestBody Brand brand) {
         return brandService.updateBrand(id, brand)
@@ -39,6 +66,12 @@ public class BrandController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Delete a brand by identifier.
+     *
+     * @param id identifier of the brand
+     * @return 204 if deleted or 404 otherwise
+     */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteBrand(@PathVariable Long id) {
         if (brandService.deleteBrand(id)) {

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/controller/HomeController.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/controller/HomeController.java
@@ -6,9 +6,17 @@ import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Simple controller exposing a basic health endpoint for the service.
+ */
 @RestController
 public class HomeController {
 
+    /**
+     * Returns a simple JSON map indicating the service is running.
+     *
+     * @return map containing {@code status} and {@code service} keys
+     */
     @GetMapping("/")
     public Map<String, String> home() {
         Map<String, String> response = new HashMap<>();

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Brand.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Brand.java
@@ -6,6 +6,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+/**
+ * Represents a filament brand or manufacturer.
+ */
 @Entity
 @Table(name = "brands")
 public class Brand {
@@ -17,9 +20,19 @@ public class Brand {
     private String website;
     private String notes;
 
+    /**
+     * Default constructor required by JPA.
+     */
     public Brand() {
     }
 
+    /**
+     * Convenience constructor.
+     *
+     * @param name    display name
+     * @param website optional brand website
+     * @param notes   additional notes
+     */
     public Brand(String name, String website, String notes) {
         this.name = name;
         this.website = website;

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Filament.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Filament.java
@@ -3,6 +3,9 @@ package com.btsaunde.vulcanft.invservice.model;
 import com.btsaunde.vulcanft.invservice.model.enums.FilamentType;
 import jakarta.persistence.*;
 
+/**
+ * Represents a specific filament product.
+ */
 @Entity
 @Table(name = "filaments")
 public class Filament {

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Roll.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Roll.java
@@ -10,6 +10,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
 
+/**
+ * Entity representing a physical roll of filament.
+ */
 @Entity
 @Table(name = "rolls")
 public class Roll {
@@ -25,6 +28,9 @@ public class Roll {
     private LocalDate dateOpened;
     private LocalDate dateSealed;
 
+    /**
+     * Convenience constructor used for manual creation of rolls.
+     */
     public Roll(Long rollId, Double startingSize, String filament, String roll, RollLocation location, LocalDate dateOpened, LocalDate dateSealed) {
         this.rollId = rollId;
         this.startingSize = startingSize;

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Spool.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/Spool.java
@@ -4,6 +4,9 @@ import com.btsaunde.vulcanft.invservice.model.enums.SpoolMaterialType;
 import com.btsaunde.vulcanft.invservice.model.enums.SpoolTemperature;
 import jakarta.persistence.*;
 
+/**
+ * Metadata describing a physical spool used to hold filament rolls.
+ */
 @Entity
 @Table(name = "spools")
 public class Spool {
@@ -29,9 +32,15 @@ public class Spool {
 
     private boolean amsCompatible;
 
+    /**
+     * Default constructor for JPA.
+     */
     public Spool() {
     }
 
+    /**
+     * Convenience constructor.
+     */
     public Spool(SpoolMaterialType materialType, double size, double emptyWeight, Brand brand, String color, SpoolTemperature temperature, boolean amsCompatible) {
         this.materialType = materialType;
         this.size = size;

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/FilamentType.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/FilamentType.java
@@ -1,5 +1,8 @@
 package com.btsaunde.vulcanft.invservice.model.enums;
 
+/**
+ * Enumeration of the supported filament materials.
+ */
 public enum FilamentType {
     ABS,
     ABS_GF,

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/RollLocation.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/RollLocation.java
@@ -1,5 +1,8 @@
 package com.btsaunde.vulcanft.invservice.model.enums;
 
+/**
+ * Possible storage locations for a roll of filament.
+ */
 public enum RollLocation {
     NEW_UNOPENED,
     AMS,

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/SpoolMaterialType.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/SpoolMaterialType.java
@@ -1,5 +1,8 @@
 package com.btsaunde.vulcanft.invservice.model.enums;
 
+/**
+ * Material used to manufacture a spool.
+ */
 public enum SpoolMaterialType {
     CARDBOARD, PLASTIC
 }

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/SpoolTemperature.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/model/enums/SpoolTemperature.java
@@ -1,5 +1,8 @@
 package com.btsaunde.vulcanft.invservice.model.enums;
 
+/**
+ * Indicates the temperature resistance of a spool.
+ */
 public enum SpoolTemperature {
     LOW, HIGH
 }

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/repository/BrandRepository.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/repository/BrandRepository.java
@@ -5,6 +5,9 @@ import org.springframework.stereotype.Repository;
 
 import com.btsaunde.vulcanft.invservice.model.Brand;
 
+/**
+ * JPA repository for {@link Brand} entities.
+ */
 @Repository
 public interface BrandRepository extends JpaRepository<Brand, Long> {
 }

--- a/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/service/BrandService.java
+++ b/inventory-service/src/main/java/com/btsaunde/vulcanft/invservice/service/BrandService.java
@@ -9,28 +9,60 @@ import org.springframework.stereotype.Service;
 import com.btsaunde.vulcanft.invservice.model.Brand;
 import com.btsaunde.vulcanft.invservice.repository.BrandRepository;
 
+/**
+ * Service layer that provides CRUD operations for {@link Brand} entities.
+ */
 @Service
 public class BrandService {
 
     @Autowired
     private final BrandRepository brandRepository;
 
+    /**
+     * Constructs a new service with the given repository.
+     *
+     * @param brandRepository repository used to store brands
+     */
     public BrandService(BrandRepository brandRepository) {
         this.brandRepository = brandRepository;
     }
 
+    /**
+     * Retrieve all brands from the repository.
+     *
+     * @return list of brands
+     */
     public List<Brand> getAllBrands() {
         return brandRepository.findAll();
     }
 
+    /**
+     * Find a brand by id.
+     *
+     * @param id brand identifier
+     * @return optional brand
+     */
     public Optional<Brand> getBrandById(Long id) {
         return brandRepository.findById(id);
     }
 
+    /**
+     * Persist a new brand.
+     *
+     * @param brand brand to store
+     * @return saved brand
+     */
     public Brand createBrand(Brand brand) {
         return brandRepository.save(brand);
     }
 
+    /**
+     * Update an existing brand.
+     *
+     * @param id    id of the brand to update
+     * @param brand new brand values
+     * @return updated brand if found
+     */
     public Optional<Brand> updateBrand(Long id, Brand brand) {
         return brandRepository.findById(id).map(existingBrand -> {
             existingBrand.setName(brand.getName());
@@ -39,6 +71,12 @@ public class BrandService {
         });
     }
 
+    /**
+     * Delete a brand by id.
+     *
+     * @param id brand identifier
+     * @return {@code true} if deleted
+     */
     public boolean deleteBrand(Long id) {
         if (brandRepository.existsById(id)) {
             brandRepository.deleteById(id);

--- a/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/controller/BrandControllerDocumentationTests.java
+++ b/inventory-service/src/test/java/com/btsaunde/vulcanft/invservice/controller/BrandControllerDocumentationTests.java
@@ -1,0 +1,46 @@
+package com.btsaunde.vulcanft.invservice.controller;
+
+import com.btsaunde.vulcanft.invservice.model.Brand;
+import com.btsaunde.vulcanft.invservice.repository.BrandRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@link BrandController} that also generate Spring REST Docs snippets.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(outputDir = "target/generated-snippets")
+class BrandControllerDocumentationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @BeforeEach
+    void setup() {
+        brandRepository.deleteAll();
+        brandRepository.save(new Brand("TestBrand", "https://example.com", "notes"));
+    }
+
+    @Test
+    void getBrands() throws Exception {
+        mockMvc.perform(get("/api/brand").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("brands-get"));
+    }
+}

--- a/inventory-service/src/test/resources/application.properties
+++ b/inventory-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add Javadoc across inventory service classes
- integrate Spring REST Docs with Asciidoctor
- document BrandController endpoints via tests

## Testing
- `mvn -B test`

------
https://chatgpt.com/codex/tasks/task_e_684246188dc0832bbb020ca2d527daa3