### PR TITLE
Integrate Spring REST Docs

### DIFF
--- a/svg-service/pom.xml
+++ b/svg-service/pom.xml
@@ -26,9 +26,10 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <snippetsDir>${project.build.directory}/generated-snippets</snippetsDir>
+        </properties>
 	<dependencies>
 		<!-- Spring Dependencies -->
 		<dependency>
@@ -39,11 +40,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-mockmvc</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 		<!-- Apache Batik Dependencies for SVG to PNG Conversion -->
 		<dependency>
@@ -56,11 +62,38 @@
 
 	<build>
 		<finalName>${project.artifactId}</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoctor-maven-plugin</artifactId>
+                                <version>2.2.1</version>
+                                <executions>
+                                        <execution>
+                                                <id>generate-docs</id>
+                                                <phase>prepare-package</phase>
+                                                <goals>
+                                                        <goal>process-asciidoc</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <backend>html</backend>
+                                                        <attributes>
+                                                                <snippets>${snippetsDir}</snippets>
+                                                        </attributes>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                                <dependencies>
+                                        <dependency>
+                                                <groupId>org.springframework.restdocs</groupId>
+                                                <artifactId>spring-restdocs-asciidoctor</artifactId>
+                                                <version>${spring-restdocs.version}</version>
+                                        </dependency>
+                                </dependencies>
+                        </plugin>
 			<!-- <plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>dockerfile-maven-plugin</artifactId>

--- a/svg-service/src/docs/asciidoc/index.adoc
+++ b/svg-service/src/docs/asciidoc/index.adoc
@@ -1,0 +1,10 @@
+= SVG Service API
+:toc: left
+:toclevels: 2
+
+== Home
+
+The following example documents the home endpoint.
+
+include::{snippets}/home/http-request.adoc[]
+include::{snippets}/home/http-response.adoc[]

--- a/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/controller/HomeControllerRestDocsTest.java
+++ b/svg-service/src/test/java/com/btsaunde/vulcanft/svgservice/controller/HomeControllerRestDocsTest.java
@@ -1,0 +1,26 @@
+package com.btsaunde.vulcanft.svgservice.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HomeController.class)
+@AutoConfigureRestDocs(outputDir = "target/generated-snippets")
+class HomeControllerRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void documentHomeEndpoint() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andDo(document("home"));
+    }
+}


### PR DESCRIPTION
## Summary
- configure REST Docs in the svg service POM
- document home endpoint with asciidoc
- test `HomeController` while generating snippets

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6842489197e8832ba28bce2842c3bc8f